### PR TITLE
Make coroutine code dependent on __cpp_lib_coroutine.

### DIFF
--- a/c9y-test/coroutine_test.cpp
+++ b/c9y-test/coroutine_test.cpp
@@ -21,6 +21,8 @@
 // SOFTWARE.
 //
 
+#ifdef __cpp_lib_coroutine
+
 #include <chrono>
 #include <coroutine>
 #include <exception>
@@ -79,3 +81,4 @@ TEST(coroutine, fail)
     EXPECT_THROW(fail().get(), std::runtime_error);
 }
 
+#endif

--- a/c9y/coroutine.h
+++ b/c9y/coroutine.h
@@ -22,6 +22,8 @@
 #ifndef _C9Y_COROUTINE_H_
 #define _C9Y_COROUTINE_H_
 
+#ifdef __cpp_lib_coroutine
+
 #include "defines.h"
 
 #include <future>
@@ -160,4 +162,5 @@ namespace c9y
     }
 }
 
+#endif
 #endif


### PR DESCRIPTION
This prevents build failures for compilers and stdlibs that do not have coroutines implemented yet.