### PR TITLE
Undefined max in latch.h

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - add missing cmake module export
+- fixed compile error on latch::max
 
 ## [0.4.0] - 2022-07-30
 

--- a/c9y/latch.h
+++ b/c9y/latch.h
@@ -28,6 +28,11 @@
 #include <mutex>
 #include <condition_variable>
 
+#ifdef max
+#warning "Undefined max. Defining the max macro will result in a compile error."
+#undef max
+#endif
+
 namespace c9y
 {
     //! latch


### PR DESCRIPTION
latch::max may result in a compile error if the max macro is defined. Generally you should never define or use the max macro.